### PR TITLE
Added remove-empty-groups option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ load-generator
 integration-tester
 dist
 /vendor
+/.vscode

--- a/cmd/process-exporter/main.go
+++ b/cmd/process-exporter/main.go
@@ -176,6 +176,7 @@ func main() {
 			"log debugging information to stdout")
 		showVersion = flag.Bool("version", false,
 			"print version information and exit")
+		removeDeadGroups = flag.Bool("remove-dead-groups", false, "forget process groups with no processes")
 	)
 	flag.Parse()
 
@@ -233,13 +234,14 @@ func main() {
 
 	pc, err := collector.NewProcessCollector(
 		collector.ProcessCollectorOption{
-			ProcFSPath:  *procfsPath,
-			Children:    *children,
-			Threads:     *threads,
-			GatherSMaps: *smaps,
-			Namer:       matchnamer,
-			Recheck:     *recheck,
-			Debug:       *debug,
+			ProcFSPath:       *procfsPath,
+			Children:         *children,
+			Threads:          *threads,
+			GatherSMaps:      *smaps,
+			Namer:            matchnamer,
+			Recheck:          *recheck,
+			Debug:            *debug,
+			RemoveDeadGroups: *removeDeadGroups,
 		},
 	)
 	if err != nil {

--- a/cmd/process-exporter/main.go
+++ b/cmd/process-exporter/main.go
@@ -176,7 +176,7 @@ func main() {
 			"log debugging information to stdout")
 		showVersion = flag.Bool("version", false,
 			"print version information and exit")
-		removeDeadGroups = flag.Bool("remove-dead-groups", false, "forget process groups with no processes")
+		removeEmptyGroups = flag.Bool("remove-empty-groups", false, "forget process groups with no processes")
 	)
 	flag.Parse()
 
@@ -234,14 +234,14 @@ func main() {
 
 	pc, err := collector.NewProcessCollector(
 		collector.ProcessCollectorOption{
-			ProcFSPath:       *procfsPath,
-			Children:         *children,
-			Threads:          *threads,
-			GatherSMaps:      *smaps,
-			Namer:            matchnamer,
-			Recheck:          *recheck,
-			Debug:            *debug,
-			RemoveDeadGroups: *removeDeadGroups,
+			ProcFSPath:        *procfsPath,
+			Children:          *children,
+			Threads:           *threads,
+			GatherSMaps:       *smaps,
+			Namer:             matchnamer,
+			Recheck:           *recheck,
+			Debug:             *debug,
+			RemoveEmptyGroups: *removeEmptyGroups,
 		},
 	)
 	if err != nil {

--- a/collector/process_collector.go
+++ b/collector/process_collector.go
@@ -155,14 +155,14 @@ type (
 	}
 
 	ProcessCollectorOption struct {
-		ProcFSPath       string
-		Children         bool
-		Threads          bool
-		GatherSMaps      bool
-		Namer            common.MatchNamer
-		Recheck          bool
-		Debug            bool
-		RemoveDeadGroups bool
+		ProcFSPath        string
+		Children          bool
+		Threads           bool
+		GatherSMaps       bool
+		Namer             common.MatchNamer
+		Recheck           bool
+		Debug             bool
+		RemoveEmptyGroups bool
 	}
 
 	NamedProcessCollector struct {
@@ -187,7 +187,7 @@ func NewProcessCollector(options ProcessCollectorOption) (*NamedProcessCollector
 	fs.GatherSMaps = options.GatherSMaps
 	p := &NamedProcessCollector{
 		scrapeChan: make(chan scrapeRequest),
-		Grouper:    proc.NewGrouper(options.Namer, options.Children, options.Threads, options.Recheck, options.Debug, options.RemoveDeadGroups),
+		Grouper:    proc.NewGrouper(options.Namer, options.Children, options.Threads, options.Recheck, options.Debug, options.RemoveEmptyGroups),
 		source:     fs,
 		threads:    options.Threads,
 		smaps:      options.GatherSMaps,

--- a/collector/process_collector.go
+++ b/collector/process_collector.go
@@ -155,13 +155,14 @@ type (
 	}
 
 	ProcessCollectorOption struct {
-		ProcFSPath  string
-		Children    bool
-		Threads     bool
-		GatherSMaps bool
-		Namer       common.MatchNamer
-		Recheck     bool
-		Debug       bool
+		ProcFSPath       string
+		Children         bool
+		Threads          bool
+		GatherSMaps      bool
+		Namer            common.MatchNamer
+		Recheck          bool
+		Debug            bool
+		RemoveDeadGroups bool
 	}
 
 	NamedProcessCollector struct {
@@ -186,7 +187,7 @@ func NewProcessCollector(options ProcessCollectorOption) (*NamedProcessCollector
 	fs.GatherSMaps = options.GatherSMaps
 	p := &NamedProcessCollector{
 		scrapeChan: make(chan scrapeRequest),
-		Grouper:    proc.NewGrouper(options.Namer, options.Children, options.Threads, options.Recheck, options.Debug),
+		Grouper:    proc.NewGrouper(options.Namer, options.Children, options.Threads, options.Recheck, options.Debug, options.RemoveDeadGroups),
 		source:     fs,
 		threads:    options.Threads,
 		smaps:      options.GatherSMaps,

--- a/proc/grouper.go
+++ b/proc/grouper.go
@@ -134,7 +134,7 @@ func (g *Grouper) groups(tracked []Update) GroupByName {
 		groups[gname] = group
 	}
 
-	// Now add any groups that were observed in the past but aren't running now (or delete them, if removeDeadGroups is True).
+	// Now add any groups that were observed in the past but aren't running now (or delete them, if removeDeadGroups is true).
 	for gname, gcounts := range g.groupAccum {
 		if _, ok := groups[gname]; !ok {
 			if g.removeDeadGroups {

--- a/proc/grouper_test.go
+++ b/proc/grouper_test.go
@@ -73,7 +73,7 @@ func TestGrouperBasic(t *testing.T) {
 		},
 	}
 
-	gr := NewGrouper(newNamer(n1, n2), false, false, false, false)
+	gr := NewGrouper(newNamer(n1, n2), false, false, false, false, false)
 	for i, tc := range tests {
 		got := rungroup(t, gr, procInfoIter(tc.procs...))
 		if diff := cmp.Diff(got, tc.want); diff != "" {
@@ -128,7 +128,7 @@ func TestGrouperProcJoin(t *testing.T) {
 		},
 	}
 
-	gr := NewGrouper(newNamer(n1), false, false, false, false)
+	gr := NewGrouper(newNamer(n1), false, false, false, false, false)
 	for i, tc := range tests {
 		got := rungroup(t, gr, procInfoIter(tc.procs...))
 		if diff := cmp.Diff(got, tc.want); diff != "" {
@@ -138,7 +138,7 @@ func TestGrouperProcJoin(t *testing.T) {
 }
 
 // TestGrouperNonDecreasing tests the disappearance of a process.  Its previous
-// contribution to the counts should not go away when that happens.
+// contribution to the counts should not go away when that happens if removeDeadGroups if false.
 func TestGrouperNonDecreasing(t *testing.T) {
 	p1, p2 := 1, 2
 	n1, n2 := "g1", "g1"
@@ -171,7 +171,49 @@ func TestGrouperNonDecreasing(t *testing.T) {
 		},
 	}
 
-	gr := NewGrouper(newNamer(n1), false, false, false, false)
+	gr := NewGrouper(newNamer(n1), false, false, false, false, false)
+	for i, tc := range tests {
+		got := rungroup(t, gr, procInfoIter(tc.procs...))
+		if diff := cmp.Diff(got, tc.want); diff != "" {
+			t.Errorf("%d: curgroups differs: (-got +want)\n%s", i, diff)
+		}
+	}
+}
+
+// TestGrouperNonDecreasing tests the disappearance of a process.
+// We want the group to disappear if removeDeadGroups if false.
+func TestGrouperRemoveDeadGroups(t *testing.T) {
+	p1, p2 := 1, 2
+	n1, n2 := "g1", "g2"
+	starttime := time.Unix(0, 0).UTC()
+
+	tests := []struct {
+		procs []IDInfo
+		want  GroupByName
+	}{
+		{
+			[]IDInfo{
+				piinfo(p1, n1, Counts{3, 4, 5, 6, 7, 8, 0, 0}, Memory{3, 4, 0, 0, 0}, Filedesc{4, 400}, 2),
+				piinfo(p2, n2, Counts{1, 1, 1, 1, 1, 1, 0, 0}, Memory{1, 2, 0, 0, 0}, Filedesc{40, 400}, 3),
+			},
+			GroupByName{
+				n1: Group{Counts{}, States{}, msi{}, 1, Memory{3, 4, 0, 0, 0}, starttime, 4, 0.01, 2, nil},
+				n2: Group{Counts{}, States{}, msi{}, 1, Memory{1, 2, 0, 0, 0}, starttime, 40, 0.1, 3, nil},
+			},
+		}, {
+			[]IDInfo{
+				piinfo(p1, n1, Counts{4, 5, 6, 7, 8, 9, 0, 0}, Memory{1, 5, 0, 0, 0}, Filedesc{4, 400}, 2),
+			},
+			GroupByName{
+				n1: Group{Counts{1, 1, 1, 1, 1, 1, 0, 0}, States{}, msi{}, 1, Memory{1, 5, 0, 0, 0}, starttime, 4, 0.01, 2, nil},
+			},
+		}, {
+			[]IDInfo{},
+			GroupByName{},
+		},
+	}
+
+	gr := NewGrouper(newNamer(n1, n2), false, false, false, false, true)
 	for i, tc := range tests {
 		got := rungroup(t, gr, procInfoIter(tc.procs...))
 		if diff := cmp.Diff(got, tc.want); diff != "" {
@@ -224,7 +266,7 @@ func TestGrouperThreads(t *testing.T) {
 	}
 
 	opts := cmpopts.SortSlices(lessThreads)
-	gr := NewGrouper(newNamer(n), false, true, false, false)
+	gr := NewGrouper(newNamer(n), false, true, false, false, false)
 	for i, tc := range tests {
 		got := rungroup(t, gr, procInfoIter(tc.proc))
 		if diff := cmp.Diff(got, tc.want, opts); diff != "" {

--- a/proc/grouper_test.go
+++ b/proc/grouper_test.go
@@ -138,7 +138,7 @@ func TestGrouperProcJoin(t *testing.T) {
 }
 
 // TestGrouperNonDecreasing tests the disappearance of a process.  Its previous
-// contribution to the counts should not go away when that happens if removeEmptyGroups if false.
+// contribution to the counts should not go away when that happens if removeEmptyGroups is false.
 func TestGrouperNonDecreasing(t *testing.T) {
 	p1, p2 := 1, 2
 	n1, n2 := "g1", "g1"
@@ -181,7 +181,7 @@ func TestGrouperNonDecreasing(t *testing.T) {
 }
 
 // TestGrouperNonDecreasing tests the disappearance of a process.
-// We want the group to disappear if removeEmptyGroups if true.
+// We want the group to disappear if removeEmptyGroups is true.
 func TestGrouperRemoveEmptyGroups(t *testing.T) {
 	p1, p2 := 1, 2
 	n1, n2 := "g1", "g2"

--- a/proc/grouper_test.go
+++ b/proc/grouper_test.go
@@ -138,7 +138,7 @@ func TestGrouperProcJoin(t *testing.T) {
 }
 
 // TestGrouperNonDecreasing tests the disappearance of a process.  Its previous
-// contribution to the counts should not go away when that happens if removeDeadGroups if false.
+// contribution to the counts should not go away when that happens if removeEmptyGroups if false.
 func TestGrouperNonDecreasing(t *testing.T) {
 	p1, p2 := 1, 2
 	n1, n2 := "g1", "g1"
@@ -181,8 +181,8 @@ func TestGrouperNonDecreasing(t *testing.T) {
 }
 
 // TestGrouperNonDecreasing tests the disappearance of a process.
-// We want the group to disappear if removeDeadGroups if false.
-func TestGrouperRemoveDeadGroups(t *testing.T) {
+// We want the group to disappear if removeEmptyGroups if true.
+func TestGrouperRemoveEmptyGroups(t *testing.T) {
 	p1, p2 := 1, 2
 	n1, n2 := "g1", "g2"
 	starttime := time.Unix(0, 0).UTC()


### PR DESCRIPTION
If this option is True (default false) we'll remove groups if they have 0 processes (by default we leave the group, assuming processes from that group will be back)

The only real change is at the end of file `proc/grouper.go` - where I remove un-found groups if remove-dead-groups is true